### PR TITLE
feat: Add ability to specify password for the redis server

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -31,7 +31,8 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             $this->_redisOptions = [
                 "timeout" => $options['redis_timeout'] ?? 5,
                 "host" => $options['redis_host'] ?? 'localhost',
-                "port" => $options['redis_port'] ?? 6379
+                "port" => $options['redis_port'] ?? 6379,
+                "password" => $options['redis_password'] ?? null
             ];
         }
     }
@@ -65,6 +66,12 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             $this->_redisOptions["timeout"],
             'launchdarkly/php-server-sdk-redis-phpredis'
         );
+        if (
+            $this->_redisOptions['password'] !== null &&
+            $this->_redisOptions['password' !== '']
+        ) {
+            $redis->auth($this->_redisOptions['password']);
+        }
         return $this->_redisInstance = $redis;
     }
 }

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -66,12 +66,11 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             $this->_redisOptions["timeout"],
             'launchdarkly/php-server-sdk-redis-phpredis'
         );
-        if (
-            $this->_redisOptions['password'] !== null &&
-            $this->_redisOptions['password' !== '']
-        ) {
+
+        if ($this->_redisOptions['password']) {
             $redis->auth($this->_redisOptions['password']);
         }
+
         return $this->_redisInstance = $redis;
     }
 }

--- a/src/LaunchDarkly/Integrations/PHPRedis.php
+++ b/src/LaunchDarkly/Integrations/PHPRedis.php
@@ -24,6 +24,7 @@ class PHPRedis
      * @param array $options  Configuration settings (can also be passed in the main client configuration):
      *   - `redis_host`: hostname of the Redis server; defaults to `localhost`
      *   - `redis_port`: port of the Redis server; defaults to 6379
+     *   - `redis_password`: password to auth against the Redis server; optional
      *   - `redis_timeout`: connection timeout in seconds; defaults to 5
      *   - `redis_prefix`: a string to be prepended to all database keys; corresponds to the prefix
      * setting in ld-relay


### PR DESCRIPTION
As the title describes, this should be a straightforward change allowing a password to be specified when connecting to the redis server. I don't anticipate that this would cause any problems, but please double check my work.

I understand that there is a `phpredis_client` client option we could use instead to pass in a functional phpredis client with a password, but this approach would be easier for us to manage due to differences in our development and production environments.

I would be grateful for a speedy release, so please let me know if I can help. Thank you for your time!